### PR TITLE
add varidation null false and limit 30 length to tasks name

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,9 +12,13 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+    @task = Task.new(task_params)
+
+    if @task.save
+    redirect_to @task, notice: "タスク「#{@task.name}」を登録しました。"
+    else
+      render :new
+    end
   end
 
   def edit

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,12 @@
 class Task < ApplicationRecord
+  validates :name, presence: true
+  validates :name, length: { maximum: 30 }
+  validate :validate_name_not_including_comma
+
+  private
+
+  def validate_name_not_including_comma
+    errors.add(:name, 'にカンマを含めることはできません') if name&.include?(',')
+  end
 end
+

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,3 +1,8 @@
+-if task.errors.present?
+  ul#error_explanation
+    - task.errors.full_messages.each do |message|
+      li = message
+
 = form_with model: task, local: true do |f|
   .form-group
     = f.label :name

--- a/db/migrate/20191216100218_change_tasks_name_not_null.rb
+++ b/db/migrate/20191216100218_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :name, false
+  end
+end

--- a/db/migrate/20191216101301_change_tasks_name_limit30.rb
+++ b/db/migrate/20191216101301_change_tasks_name_limit30.rb
@@ -1,0 +1,9 @@
+class ChangeTasksNameLimit30 < ActiveRecord::Migration[5.2]
+  def up
+    change_column :tasks, :name, :string, limit: 30
+  end
+
+  def down
+    change_column :tasks, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_13_153452) do
+ActiveRecord::Schema.define(version: 2019_12_16_101301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 30, null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## what 
- migration fileでtasks table name column にNot Null制約と最大文字数30の制約を追加
- Task model に上記と同じvalidatesを追加
- task の新規作成/編集フォームにエラーメッセージがあれば表示する記述を追加